### PR TITLE
wip: support previously registered U2F factors as WebAuthN factors.

### DIFF
--- a/api/factors.go
+++ b/api/factors.go
@@ -79,6 +79,10 @@ func (f *Factor) UnmarshalJSON(data []byte) error {
 		profile := FactorProfileU2F{}
 		err = json.Unmarshal([]byte(factor.Profile), &profile)
 		f.Profile = profile
+	case factors.FactorTypeWebAuthN:
+		profile := FactorProfileWebAuthN{}
+		err = json.Unmarshal([]byte(factor.Profile), &profile)
+		f.Profile = profile
 	default:
 		// Ignore any profile contents we don't understand
 		return nil
@@ -92,6 +96,7 @@ type FactorEmbedded struct {
 }
 
 type Challenge struct {
+	Challenge      string
 	Nonce          string
 	TimeoutSeconds int
 }
@@ -121,6 +126,10 @@ type FactorProfileU2F struct {
 	Version      string `json:"version,omitempty"`
 }
 
+type FactorProfileWebAuthN struct {
+	CredentialId string `json:"credentialId,omitempty"`
+}
+
 type FactorVerify struct {
 	StateToken string `json:"stateToken"`
 }
@@ -141,6 +150,13 @@ type FactorVerifyPush struct {
 	FactorVerify
 }
 
+type FactorVerifyWebAuthN struct {
+	FactorVerify
+	ClientData        string `json:"clientData"`
+	SignatureData     string `json:"signatureData"`
+	AuthenticatorData string `json:"authenticatorData"`
+}
+
 func indexOfFactorType(factorType factors.FactorType) int {
 	for i, t := range knownFactors {
 		if factorType == t {
@@ -152,6 +168,7 @@ func indexOfFactorType(factorType factors.FactorType) int {
 
 var knownFactors = []factors.FactorType{
 	factors.FactorTypeU2F,
+	factors.FactorTypeWebAuthN,
 	factors.FactorTypeToken,
 	factors.FactorTypeTokenSoftwareTOTP,
 	factors.FactorTypeTokenHardware,

--- a/api/factors_test.go
+++ b/api/factors_test.go
@@ -47,6 +47,22 @@ func TestFactorUnmarshalJSON(t *testing.T) {
 				},
 			},
 		},
+		{
+			input: sampleWebAuthNFactor,
+			expected: Factor{
+				Id:         "fufb6rh45mUxtEJz61t7",
+				FactorType: factors.FactorTypeWebAuthN,
+				Provider:   "FIDO",
+				Profile: FactorProfileWebAuthN{
+					CredentialId: "s94CdJnUd148p95PNq7AaY2Dv1QFrLJ12Vpkno-Q7WalmBTtB5TMnzDNL_yX84Ay49qnEiUXtSx0KK5I60ht2g",
+				},
+				Links: Links{
+					Verify: Link{
+						HREF: "https://example.okta.com/api/v1/authn/factors/fufb6rh45mUxtEJz61t7/verify",
+					},
+				},
+			},
+		},
 	}
 
 	for i, testCase := range testCases {
@@ -98,6 +114,28 @@ var sampleU2FFactor = `
   "_links": {
     "verify": {
       "href": "https:\/\/example.okta.com\/api\/v1\/authn\/factors\/fuf59d1ohqJZyOelX1t7\/verify",
+      "hints": {
+        "allow": [
+          "POST"
+        ]
+      }
+    }
+  }
+}
+`
+
+var sampleWebAuthNFactor = `
+{
+  "id": "fufb6rh45mUxtEJz61t7",
+  "factorType": "webauthn",
+  "provider": "FIDO",
+  "vendorName": "FIDO",
+  "profile": {
+    "credentialId": "s94CdJnUd148p95PNq7AaY2Dv1QFrLJ12Vpkno-Q7WalmBTtB5TMnzDNL_yX84Ay49qnEiUXtSx0KK5I60ht2g"
+  },
+  "_links": {
+    "verify": {
+      "href": "https://example.okta.com/api/v1/authn/factors/fufb6rh45mUxtEJz61t7/verify",
       "hints": {
         "allow": [
           "POST"

--- a/factors/factors.go
+++ b/factors/factors.go
@@ -7,6 +7,7 @@ const (
 	FactorTypeSMS               = FactorType("sms")
 	FactorTypeCall              = FactorType("call")
 	FactorTypeU2F               = FactorType("u2f")
+	FactorTypeWebAuthN          = FactorType("webauthn")
 	FactorTypeToken             = FactorType("token")
 	FactorTypeTokenSoftwareTOTP = FactorType("token:software:totp")
 	FactorTypeTokenHardware     = FactorType("token:hardware")


### PR DESCRIPTION
Okta transitioned all of our u2f factors to webauthn. This change does the bare
minimum to support them, but probably does not properly support true webauthn
factors.